### PR TITLE
CRET-86, apply naming standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_log_analytics_workspace_name"></a> [log\_analytics\_workspace\_name](#input\_log\_analytics\_workspace\_name) | Name of log analytics workspace to be created for Sentinel storage | `string` | n/a | yes |
+| <a name="input_customer_name"></a> [customer\_name](#input\_customer\_name) | Customer name used when creating log analytics workspace. Example 'LAW-ManagedSentinel-<customer\_name>' | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_retention"></a> [log\_analytics\_workspace\_retention](#input\_log\_analytics\_workspace\_retention) | Retention period in days to retain data in the log analytics workspace | `string` | `"30"` | no |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group to be imported. | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group to be imported. | `string` | `"rg-ManagedSentinel"` | no |
 
 ## Outputs
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -1,12 +1,12 @@
 resource "azurerm_resource_group" "sentinel-test-advanced" {
-  name = "rg-test-advanced-sentinel"
+  name     = "rg-ManagedSentinel"
   location = "UKSouth"
 }
 
 module "sentinel" {
-  source = "github.com/SoftcatMS/terraform-azure-sentinel"
+  source              = "github.com/SoftcatMS/terraform-azure-sentinel"
   resource_group_name = azurerm_resource_group.sentinel-test-advanced.name
-  log_analytics_workspace_name = "UKS-LOG-SOFTCAT-SENTINEL-TEST-ADVANCED"
+  customer_name       = "TEST-ADVANCED"
 
   depends_on = [
     azurerm_resource_group.sentinel-test-advanced
@@ -14,7 +14,7 @@ module "sentinel" {
 }
 
 resource "azurerm_sentinel_data_connector_office_365" "sentinel" {
-  name = "SENTINEL-O365-CONNECTOR"
+  name                       = "SENTINEL-O365-CONNECTOR"
   log_analytics_workspace_id = module.sentinel.log_analytics_workspace_id
 
   depends_on = [

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,12 +1,12 @@
 resource "azurerm_resource_group" "sentinel-test-basic" {
-  name = "rg-test-basic-sentinel"
+  name     = "rg-ManagedSentinel"
   location = "UKSouth"
 }
 
 module "sentinel" {
-  source = "github.com/SoftcatMS/terraform-azure-sentinel"
+  source              = "github.com/SoftcatMS/terraform-azure-sentinel"
   resource_group_name = azurerm_resource_group.sentinel-test-basic.name
-  log_analytics_workspace_name = "UKS-LOG-SOFTCAT-SENTINEL-TEST-BASIC"
+  customer_name       = "TEST-BASIC"
 
   depends_on = [
     azurerm_resource_group.sentinel-test-basic

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ data "azurerm_resource_group" "sentinel" {
 }
 
 resource "azurerm_log_analytics_workspace" "sentinel" {
-  name = var.log_analytics_workspace_name
+  name = join("-", ["LAW-ManagedSentinel", (var.customer_name)])
   location = data.azurerm_resource_group.sentinel.location
   resource_group_name = data.azurerm_resource_group.sentinel.name
   sku = "PerGB2018"

--- a/tests/advanced/main.tf
+++ b/tests/advanced/main.tf
@@ -1,12 +1,12 @@
 resource "azurerm_resource_group" "sentinel-test-advanced" {
-  name = "rg-test-advanced-sentinel"
+  name     = "rg-test-advanced-sentinel"
   location = "UKSouth"
 }
 
 module "sentinel" {
-  source = "../../"
+  source              = "../../"
   resource_group_name = azurerm_resource_group.sentinel-test-advanced.name
-  log_analytics_workspace_name = "UKS-LOG-SOFTCAT-SENTINEL-TEST-ADVANCED"
+  customer_name       = "TEST-ADVANCED"
 
   depends_on = [
     azurerm_resource_group.sentinel-test-advanced
@@ -14,7 +14,7 @@ module "sentinel" {
 }
 
 resource "azurerm_sentinel_data_connector_office_365" "sentinel" {
-  name = "SENTINEL-O365-CONNECTOR"
+  name                       = "SENTINEL-O365-CONNECTOR"
   log_analytics_workspace_id = module.sentinel.log_analytics_workspace_id
 
   depends_on = [

--- a/tests/basic/main.tf
+++ b/tests/basic/main.tf
@@ -1,12 +1,12 @@
 resource "azurerm_resource_group" "sentinel-test-basic" {
-  name = "rg-test-basic-sentinel"
+  name     = "rg-test-basic-sentinel"
   location = "UKSouth"
 }
 
 module "sentinel" {
-  source = "../../"
+  source              = "../../"
   resource_group_name = azurerm_resource_group.sentinel-test-basic.name
-  log_analytics_workspace_name = "UKS-LOG-SOFTCAT-SENTINEL-TEST-BASIC"
+  customer_name       = "TEST-BASIC"
 
   depends_on = [
     azurerm_resource_group.sentinel-test-basic

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,18 @@
 variable "resource_group_name" {
   description = "Name of the resource group to be imported."
   type        = string
+  default     = "rg-ManagedSentinel"
 }
 
-variable "log_analytics_workspace_name" {
-  description = "Name of log analytics workspace to be created for Sentinel storage"
-  type = string
+variable "customer_name" {
+  description = "Customer name used when creating log analytics workspace. Example 'LAW-ManagedSentinel-<customer_name>'"
+  type        = string
 }
 
 variable "log_analytics_workspace_retention" {
   description = "Retention period in days to retain data in the log analytics workspace"
-  type = string
-  default = "30"
+  type        = string
+  default     = "30"
 }
 
 


### PR DESCRIPTION
Applying naming standards provided by Security Teams

•	Subscription (Managed Security - Sentinel) *Note, for greenfield only. Brownfield customers will already have a subscription unless a new subscription will be creaated in their tenant for the managed sentinel service.
•	Resource Group (rg-ManagedSentinel)
•	Log Analytics Workspace (LAW-ManagedSentinel-<customername>) This has changed to include the customer name for all ongoing onboards to easily identify customer workspaces for the multiple incident view and cross workspace query targets.
